### PR TITLE
Correction de l'url de phantomjs

### DIFF
--- a/phantomjs/recipes/default.rb
+++ b/phantomjs/recipes/default.rb
@@ -1,16 +1,12 @@
-arch = nil
-if `uname -p` =~ /x86_64/
-  arch = "x86_64"
-else
-  arch = "i686"
-end
+arch = `uname -p` =~ /x86_64/ ? 'x86_64' : 'i686'
+phantomjs = "phantomjs-1.9.8-linux-#{arch}"
 
 bash "install_phantomjs" do
   user "root"
   cwd "/tmp"
   code <<-EOH
-    wget https://phantomjs.googlecode.com/files/phantomjs-1.9.0-linux-#{arch}.tar.bz2
-    tar -xjf phantomjs-1.9.0-linux-#{arch}.tar.bz2
-    mv phantomjs-1.9.0-linux-#{arch}/bin/phantomjs /usr/local/bin/
+    wget https://bitbucket.org/ariya/phantomjs/downloads/#{phantomjs}.tar.bz2
+    tar -xjf #{phantomjs}.tar.bz2
+    mv #{phantomjs}/bin/phantomjs /usr/local/bin/
   EOH
 end


### PR DESCRIPTION
Phantomjs n'est plus hébergé sur google code,
à la place le lien doit pointer vers bitbucket.
